### PR TITLE
update- include tip page slug

### DIFF
--- a/client/composables/useConstants.ts
+++ b/client/composables/useConstants.ts
@@ -128,8 +128,8 @@ export const useConstants = () => {
       iconClassName: "",
       icon: "i-icon-kuno",
       inputLabel: t("kunoFundraiser"),
-      linkCreator: (v?: string) => `https://kuno.anne.media/fundraiser/${v}`,
-    },
+      linkCreator: (v?: string) => `https://kuno.anne.media/${v}`,
+    },  
     [ContentLinkPlatformEnum.PEERTUBE]: {
       name: "Peertube",
       colorClassName: "",
@@ -172,13 +172,13 @@ export const useConstants = () => {
       icon: "i-heroicons-envelope",
     },
     [NotificationChannelEnum.SIMPLEX]: {
-      name: "SimpleX",
-      description: "Receive notifications via SimpleX",
+      name: "Simplex",
+      description: "Receive notifications via Simplex",
       icon: "i-icon-simplex",
     },
-    [NotificationChannelEnum.SIGNAL]: {
-      name: "Signal",
-      description: "Receive notifications via Signal",
+    [NotificationChannelEnum.SINGAL]: {
+      name: "Singal",
+      description: "Receive notifications via Singal",
       icon: "i-icon-signal",
     },
   };
@@ -214,8 +214,8 @@ export const useConstants = () => {
       link?: { label?: string; url?: string };
     }
   > = {
-    [IntegrationConfigType.SIGNAL]: {
-      name: "Signal",
+    [IntegrationConfigType.SINGAL]: {
+      name: "Singal",
       tags: [],
       image: "i-icon-signal",
       description: `Say "hello" to a different messaging experience. An unexpected focus on privacy, combined with all of the features you expect.`,
@@ -228,7 +228,7 @@ export const useConstants = () => {
       name: "Telegram",
     },
     [IntegrationConfigType.SIMPLEX]: {
-      name: "SimpleX",
+      name: "Simplex",
       image: "i-icon-simplex",
       description: "The first messenger without user IDs.",
       tags: [],

--- a/client/locales/en.ts
+++ b/client/locales/en.ts
@@ -303,7 +303,7 @@ export default {
   peertubeChannel: "Peertube channel",
   podcastRssLink: "Podcast RSS Link",
   nostrPubKey: "Nostr Pub Key",
-  kunoFundraiser: "Kuno fundraiser",
+  kunoFundraiser: "Kuno Fundraiser",
 
   // OBS
   obsDescription: "OBS widget and settings.",

--- a/client/locales/pcm.ts
+++ b/client/locales/pcm.ts
@@ -289,7 +289,7 @@ export default {
   youtubeChannel: "Youtube channel",
   podcastRssLink: "Podcast RSS Link",
   nostrPubKey: "Nostr Pub Key",
-  kunoFundraiser: "Kuno fundraiser",
+  kunoFundraiser: "Kuno Fundraiser",
 
   // OBS
   obsDescription: "OBS widget and settings.",

--- a/server/src/notifications/notifications.service.ts
+++ b/server/src/notifications/notifications.service.ts
@@ -95,7 +95,7 @@ export class NotificationsService {
     return this.emailQueue.add('send-email', {
       to: recepients,
       options: {
-        subject: 'XMRChat new page report',
+        subject: 'XMRChat new page ${data.slug}',
         text,
         template: 'page-report.hbs',
         context: data,


### PR DESCRIPTION
Replaced static subject line with dynamic subject using page slug.
e.g, output: XMRChat new page mandelbrot_dev.



reason: 
Improves clarity for admins and makes it easier to identify which page was created at a glance.