### PR TITLE
 Add PeerTube live stream support

### DIFF
--- a/client/components/LiveStream/Embed/LiveStreamPeertube.vue
+++ b/client/components/LiveStream/Embed/LiveStreamPeertube.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { LiveStream } from "~/types";
+
+const props = defineProps<{
+  liveStream?: LiveStream;
+}>();
+
+const iframeUrl = computed(() => props.liveStream?.embedUrl);
+</script>
+
+<template>
+  <iframe
+    v-if="iframeUrl"
+    :src="iframeUrl"
+    allowfullscreen
+    class="w-full aspect-[16/9] rounded-md"
+  ></iframe>
+</template>

--- a/client/components/LiveStream/Embed/LiveStreamPlayer.vue
+++ b/client/components/LiveStream/Embed/LiveStreamPlayer.vue
@@ -22,4 +22,8 @@ const type = computed(() => props.liveStream?.platform);
     v-if="type === LiveStreamPlatformEnum.RUMBLE"
     :liveStream="liveStream"
   />
+  <LiveStreamPeertube
+    v-if="type === LiveStreamPlatformEnum.PEERTUBE"
+    :liveStream="liveStream"
+  />
 </template>

--- a/client/composables/useConstants.ts
+++ b/client/composables/useConstants.ts
@@ -337,6 +337,11 @@ export const useConstants = () => {
       icon: "i-tabler-brand-rumble",
       colorClassName: "text-[#85c742]",
     },
+    [LiveStreamPlatformEnum.PEERTUBE]: {
+      name: "Peertube",
+      icon: "i-icon-peertube",
+      colorClassName: "",
+    },
   };
 
   const getLiveStreamPlatform = (v?: LiveStreamPlatformEnum) => {

--- a/client/composables/useLiveStreamPlayer.ts
+++ b/client/composables/useLiveStreamPlayer.ts
@@ -24,6 +24,12 @@ export const useLiveStreamPlayer = (
     )
   );
 
+  const peertube = computed(() =>
+    streams.value?.find(
+      (stream) => stream.platform === LiveStreamPlatformEnum.PEERTUBE
+    )
+  );
+
   const livePlatforms = computed<LiveStreamPlatformEnum[]>(
     () =>
       streams.value?.map((stream) => stream.platform).filter((p) => !!p) || []
@@ -31,6 +37,7 @@ export const useLiveStreamPlayer = (
 
   const liveStreamComputed = computed(() => {
     if (twitch.value) return twitch.value;
+    if (peertube.value) return peertube.value;
     if (youtube.value) return youtube.value;
     if (rumble.value) return rumble.value;
   });

--- a/client/types/enums.ts
+++ b/client/types/enums.ts
@@ -111,6 +111,7 @@ export enum LiveStreamPlatformEnum {
   TWITCH = "twitch",
   X = "x",
   RUMBLE = "rumble",
+  PEERTUBE = "peertube",
 }
 
 export enum CohostInvitationStatusEnum {

--- a/client/types/general.ts
+++ b/client/types/general.ts
@@ -293,6 +293,7 @@ export interface LiveStream {
   platform?: LiveStreamPlatformEnum;
   page?: StreamerPage;
   videoId?: string;
+  embedUrl?: string;
 }
 
 export interface CohostInvitation {

--- a/server/src/integrations/peertube/peertube.module.ts
+++ b/server/src/integrations/peertube/peertube.module.ts
@@ -1,0 +1,10 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { PeertubeService } from './peertube.service';
+
+@Module({
+  imports: [HttpModule.register({})],
+  providers: [PeertubeService],
+  exports: [PeertubeService],
+})
+export class PeertubeModule {}

--- a/server/src/integrations/peertube/peertube.service.ts
+++ b/server/src/integrations/peertube/peertube.service.ts
@@ -1,0 +1,94 @@
+import { HttpService } from '@nestjs/axios';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { getAxiosMessage } from 'src/shared/utils/errors';
+
+export interface PeertubeVideo {
+  id?: number;
+  uuid?: string;
+  shortUUID?: string;
+  name?: string;
+  description?: string;
+  truncatedDescription?: string;
+  isLive?: boolean;
+  viewers?: number;
+  thumbnailPath?: string;
+  previewPath?: string;
+  thumbnails?: { fileUrl?: string; width?: number }[];
+  embedPath?: string;
+  createdAt?: string;
+  publishedAt?: string;
+  channel?: {
+    name?: string;
+    displayName?: string;
+  };
+}
+
+type PeertubeChannelUrl = {
+  origin: string;
+  channel: string;
+};
+
+@Injectable()
+export class PeertubeService {
+  constructor(private http: HttpService) {}
+
+  async getLiveStreams(
+    url?: string,
+  ): Promise<{ origin: string; streams: PeertubeVideo[] }> {
+    const { origin, channel } = this.parseChannelUrl(url);
+
+    try {
+      const endpoint = `${origin}/api/v1/video-channels/${encodeURIComponent(channel)}/videos`;
+      const { data } = await this.http.axiosRef.get<{
+        data?: PeertubeVideo[];
+      }>(endpoint, {
+        params: {
+          count: 25,
+          isLive: true,
+        },
+      });
+
+      return {
+        origin,
+        streams: (data.data || []).filter((video) => video.isLive),
+      };
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Error getting list of livestreams from peertube. ${getAxiosMessage(error)}`,
+      );
+    }
+  }
+
+  parseChannelUrl(url?: string): PeertubeChannelUrl {
+    if (!url) throw new BadRequestException('URL is required');
+
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new BadRequestException('A valid PeerTube URL is required');
+    }
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new BadRequestException('PeerTube URL must use http or https');
+    }
+
+    const origin = parsed.origin;
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    const [type, channel] = parts;
+
+    if (
+      (type === 'video-channels' || type === 'c') &&
+      channel &&
+      (parts.length === 2 || (parts.length === 3 && parts[2] === 'videos'))
+    ) {
+      return { origin, channel };
+    }
+
+    throw new BadRequestException('A PeerTube channel URL is required');
+  }
+}

--- a/server/src/live-streams/dtos/live-stream.dto.ts
+++ b/server/src/live-streams/dtos/live-stream.dto.ts
@@ -1,4 +1,4 @@
-import { Expose, Type } from 'class-transformer';
+import { Expose, Transform, Type } from 'class-transformer';
 import { PageDto } from 'src/pages/dtos/page.dto';
 import { LiveStreamPlatformEnum } from 'src/shared/constants';
 
@@ -32,6 +32,12 @@ export class LiveStreamDto {
 
   @Expose()
   videoId: string;
+
+  @Expose()
+  @Transform(({ obj }) => {
+    if (obj.data?.embedUrl) return obj.data.embedUrl;
+  })
+  embedUrl: string;
 
   @Expose()
   @Type(() => PageDto)

--- a/server/src/live-streams/live-streams.module.ts
+++ b/server/src/live-streams/live-streams.module.ts
@@ -14,12 +14,15 @@ import { TwitchModule } from 'src/integrations/twitch/twitch.module';
 import { RumbleModule } from 'src/integrations/rumble/rumble.module';
 import { RumbleProvider } from './providers/rumble.provider';
 import { QueuesModule } from 'src/queues/queues.module';
+import { PeertubeModule } from 'src/integrations/peertube/peertube.module';
+import { PeertubeProvider } from './providers/peertube.provider';
 
 @Module({
   imports: [
     YoutubeModule,
     TwitchModule,
     RumbleModule,
+    PeertubeModule,
     LinksModule,
     TypeOrmModule.forFeature([LiveStream, Link, Page]),
     QueuesModule,
@@ -30,6 +33,7 @@ import { QueuesModule } from 'src/queues/queues.module';
     YoutubeProvider,
     TwitchProvider,
     RumbleProvider,
+    PeertubeProvider,
     LiveStreamProcessor,
   ],
   exports: [LiveStreamsService],

--- a/server/src/live-streams/live-streams.service.ts
+++ b/server/src/live-streams/live-streams.service.ts
@@ -18,6 +18,7 @@ import { Page } from 'src/pages/page.entity';
 import { RumbleProvider } from './providers/rumble.provider';
 import { Link } from 'src/links/link.entity';
 import { Tip } from 'src/tips/tip.entity';
+import { PeertubeProvider } from './providers/peertube.provider';
 
 @Injectable()
 export class LiveStreamsService implements OnModuleInit {
@@ -28,6 +29,7 @@ export class LiveStreamsService implements OnModuleInit {
     private youtubeProvider: YoutubeProvider,
     private twitchProvider: TwitchProvider,
     private rumbleProvider: RumbleProvider,
+    private peertubeProvider: PeertubeProvider,
     private config: ConfigService,
     @InjectRepository(LiveStream) private repo: Repository<LiveStream>,
     @InjectRepository(Page) private pagesRepo: Repository<Page>,
@@ -53,9 +55,10 @@ export class LiveStreamsService implements OnModuleInit {
       .addOrderBy(
         `CASE 
           WHEN liveStream.platform = '${LiveStreamPlatformEnum.TWITCH}' THEN 1
-          WHEN liveStream.platform = '${LiveStreamPlatformEnum.YOUTUBE}' THEN 2
-          WHEN liveStream.platform = '${LiveStreamPlatformEnum.RUMBLE}' THEN 3
-          ELSE 4
+          WHEN liveStream.platform = '${LiveStreamPlatformEnum.PEERTUBE}' THEN 2
+          WHEN liveStream.platform = '${LiveStreamPlatformEnum.YOUTUBE}' THEN 3
+          WHEN liveStream.platform = '${LiveStreamPlatformEnum.RUMBLE}' THEN 4
+          ELSE 5
         END`,
         'ASC',
       )
@@ -92,8 +95,14 @@ export class LiveStreamsService implements OnModuleInit {
     const youtube = await this.getYoutubeLiveStreams();
     const twitch = await this.getTwitchLiveStreams();
     const rumble = await this.getRumbleLiveStreams();
+    const peertube = await this.getPeertubeLiveStreams();
 
-    await this.updateLiveStreams([...youtube, ...twitch, ...rumble]);
+    await this.updateLiveStreams([
+      ...youtube,
+      ...twitch,
+      ...rumble,
+      ...peertube,
+    ]);
     const result = await this.findAll();
     return result;
   }
@@ -197,5 +206,9 @@ export class LiveStreamsService implements OnModuleInit {
     }));
 
     return this.rumbleProvider.getLiveStreams(params);
+  }
+
+  async getPeertubeLiveStreams() {
+    return this.peertubeProvider.getLiveStreams();
   }
 }

--- a/server/src/live-streams/providers/peertube.provider.ts
+++ b/server/src/live-streams/providers/peertube.provider.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  PeertubeService,
+  PeertubeVideo,
+} from 'src/integrations/peertube/peertube.service';
+import { LinksService } from 'src/links/links.service';
+import { LinkPlatformEnum, LiveStreamPlatformEnum } from 'src/shared/constants';
+import { getErrorMessage } from 'src/shared/utils/errors';
+import { CreateLiveStreamDto } from '../dtos/create-live-stream.dto';
+
+@Injectable()
+export class PeertubeProvider {
+  private logger = new Logger(PeertubeProvider.name);
+
+  constructor(
+    private readonly linksService: LinksService,
+    private readonly peertubeService: PeertubeService,
+  ) {}
+
+  async getLiveStreams(): Promise<CreateLiveStreamDto[]> {
+    const links = await this.linksService.findByPlatform(
+      LinkPlatformEnum.PEERTUBE,
+    );
+    if (!links.length) return [];
+
+    const requests = links.map(async (link) => {
+      try {
+        const result = await this.peertubeService.getLiveStreams(link.value);
+        return { ...result, pageId: link.page.id };
+      } catch (error) {
+        this.logger.warn(
+          `Failed to get peertube live streams for page ${link.page.id}: ${getErrorMessage(error)}`,
+        );
+      }
+    });
+
+    const responses = await Promise.all(requests);
+    const result: { pageId: number; origin: string; stream: PeertubeVideo }[] =
+      [];
+
+    responses
+      .filter((r) => r?.streams?.length)
+      .forEach((r) => {
+        r.streams.forEach((stream) => {
+          result.push({
+            pageId: r.pageId,
+            origin: r.origin,
+            stream,
+          });
+        });
+      });
+
+    return result.map(({ pageId, origin, stream }) => ({
+      title: stream.name,
+      description: stream.description || stream.truncatedDescription,
+      imageUrl: this.getImageUrl(stream, origin),
+      platform: LiveStreamPlatformEnum.PEERTUBE,
+      viewerCount: stream.viewers,
+      videoId: stream.shortUUID || stream.uuid || String(stream.id || ''),
+      channelId: stream.channel?.name,
+      channelName: stream.channel?.displayName || stream.channel?.name,
+      startedAt: stream.publishedAt || stream.createdAt,
+      data: { embedUrl: this.getEmbedUrl(stream, origin) },
+      pageId,
+    }));
+  }
+
+  private getImageUrl(stream: PeertubeVideo, origin: string) {
+    const thumbnail = stream.thumbnails
+      ?.slice()
+      .sort((a, b) => (b.width || 0) - (a.width || 0))
+      .find((item) => item.fileUrl);
+
+    if (thumbnail?.fileUrl) return thumbnail.fileUrl;
+    if (stream.previewPath) return `${origin}${stream.previewPath}`;
+    if (stream.thumbnailPath) return `${origin}${stream.thumbnailPath}`;
+  }
+
+  private getEmbedUrl(stream: PeertubeVideo, origin: string) {
+    if (stream.embedPath) return `${origin}${stream.embedPath}`;
+
+    const videoId = stream.shortUUID || stream.uuid || stream.id;
+    if (videoId) return `${origin}/videos/embed/${videoId}`;
+  }
+}

--- a/server/src/shared/constants/enum.ts
+++ b/server/src/shared/constants/enum.ts
@@ -172,6 +172,7 @@ export enum LiveStreamPlatformEnum {
   TWITCH = 'twitch',
   X = 'x',
   RUMBLE = 'rumble',
+  PEERTUBE = 'peertube',
 }
 
 export enum CohostInvitationStatus {


### PR DESCRIPTION
# Summary

  Adds PeerTube as a supported live stream platform.

  Streamers can add a full PeerTube channel URL to their content links, and the live stream refresh job will detect
  currently live videos and expose them through the existing live stream APIs, search/live indicators, streamer
  pages, and embedded player.

  ## Changes

  - Add PeerTube backend integration and live stream provider.
  - Use the existing PeerTube content link URL to discover live streams.
  - Support PeerTube channel URLs:
    - `/video-channels/:channel`
    - `/c/:channel`
    - the same channel URLs with trailing `/videos`
  - Add PeerTube to live stream enums, DTOs, constants, and frontend types.
  - Render PeerTube streams with a new embed component.
  - Include PeerTube in manual/scheduled live stream refresh.
  - Set stream priority to Twitch -> PeerTube -> YouTube -> Rumble -> other.
  - Expose only `embedUrl` to the client instead of exposing raw stream `data`.

  ## Testing

  - Rebased PR onto `dev`.
  - Started backend and frontend locally.
  - Verified a live PeerTube channel is detected from the saved full PeerTube channel URL.
  - Verified `/live-streams` returns the PeerTube live stream.
  - Verified `/pages/test-page` includes the PeerTube live stream and embed URL.


<img width="320" height="181" alt="image" src="https://github.com/user-attachments/assets/b60acd86-f0e4-4110-893b-42656a7793ea" />
