### PR TITLE
Add Kick live stream support

### DIFF
--- a/client/components/LiveStream/Embed/LiveStreamKick.vue
+++ b/client/components/LiveStream/Embed/LiveStreamKick.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { LiveStream } from "~/types";
+
+const props = defineProps<{
+  liveStream?: LiveStream;
+}>();
+
+const channel = computed(
+  () => props.liveStream?.channelName || props.liveStream?.videoId,
+);
+
+const iframeUrl = computed(() => {
+  if (!channel.value) return;
+  return `https://player.kick.com/${channel.value}`;
+});
+</script>
+
+<template>
+  <iframe
+    v-if="iframeUrl"
+    :src="iframeUrl"
+    allowfullscreen
+    class="w-full aspect-[16/9] rounded-md"
+  ></iframe>
+</template>

--- a/client/components/LiveStream/Embed/LiveStreamPlayer.vue
+++ b/client/components/LiveStream/Embed/LiveStreamPlayer.vue
@@ -18,6 +18,10 @@ const type = computed(() => props.liveStream?.platform);
     v-if="type === LiveStreamPlatformEnum.TWITCH"
     :liveStream="liveStream"
   />
+  <LiveStreamKick
+    v-if="type === LiveStreamPlatformEnum.KICK"
+    :liveStream="liveStream"
+  />
   <LiveStreamRumble
     v-if="type === LiveStreamPlatformEnum.RUMBLE"
     :liveStream="liveStream"

--- a/client/composables/useConstants.ts
+++ b/client/composables/useConstants.ts
@@ -327,6 +327,11 @@ export const useConstants = () => {
       icon: "i-tabler-brand-twitch",
       colorClassName: "text-[#6441a5]",
     },
+    [LiveStreamPlatformEnum.KICK]: {
+      name: "Kick",
+      icon: "i-tabler-brand-kick",
+      colorClassName: "text-[#53FC19]",
+    },
     [LiveStreamPlatformEnum.X]: {
       name: "X",
       icon: "i-tabler-brand-x",

--- a/client/composables/useLiveStreamPlayer.ts
+++ b/client/composables/useLiveStreamPlayer.ts
@@ -18,6 +18,12 @@ export const useLiveStreamPlayer = (
     )
   );
 
+  const kick = computed(() =>
+    streams.value?.find(
+      (stream) => stream.platform === LiveStreamPlatformEnum.KICK
+    )
+  );
+
   const rumble = computed(() =>
     streams.value?.find(
       (stream) => stream.platform === LiveStreamPlatformEnum.RUMBLE
@@ -37,6 +43,7 @@ export const useLiveStreamPlayer = (
 
   const liveStreamComputed = computed(() => {
     if (twitch.value) return twitch.value;
+    if (kick.value) return kick.value;
     if (peertube.value) return peertube.value;
     if (youtube.value) return youtube.value;
     if (rumble.value) return rumble.value;

--- a/client/types/enums.ts
+++ b/client/types/enums.ts
@@ -109,6 +109,7 @@ export enum PageRecipientVariant {
 export enum LiveStreamPlatformEnum {
   YOUTUBE = "youtube",
   TWITCH = "twitch",
+  KICK = "kick",
   X = "x",
   RUMBLE = "rumble",
   PEERTUBE = "peertube",

--- a/server/.env.example
+++ b/server/.env.example
@@ -71,6 +71,9 @@ TWITCH_IMPLICIT_FLOW_ACCESS_TOKEN= # Token generated from implicit flow, example
 TWITCH_CLIENT_ID= # Client id of the application created on twitch
 TWITCH_CLIENT_SECRET= # Client secret of the application created on twitch
 
+KICK_CLIENT_ID= # Client id of the application created on Kick
+KICK_CLIENT_SECRET= # Client secret of the application created on Kick
+
 TWITTER_BEARER_TOKEN= # Bearer token from X developers
 
 

--- a/server/src/integrations/kick/kick-token.service.ts
+++ b/server/src/integrations/kick/kick-token.service.ts
@@ -1,0 +1,99 @@
+import { HttpService } from '@nestjs/axios';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cache } from 'cache-manager';
+import { getAxiosMessage, getErrorMessage } from 'src/shared/utils/errors';
+
+@Injectable()
+export class KickTokenService implements OnModuleInit {
+  private logger = new Logger(KickTokenService.name);
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+  ) {}
+
+  async onModuleInit() {
+    try {
+      await this.getClientToken();
+    } catch (error) {
+      this.logger.error(`On module init: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async getClientToken() {
+    const token = await this.getCachedToken();
+
+    if (token) return token;
+
+    return this.getAndSaveClientToken();
+  }
+
+  async getAndSaveClientToken() {
+    const clientId = this.configService.get('KICK_CLIENT_ID');
+    const clientSecret = this.configService.get('KICK_CLIENT_SECRET');
+
+    if (!clientId || !clientSecret) {
+      this.logger.warn(
+        'KICK_CLIENT_ID or KICK_CLIENT_SECRET are not set. Kick client credentials token can not be generated.',
+      );
+
+      return null;
+    }
+
+    try {
+      const { data } = await this.httpService.axiosRef.post<{
+        access_token: string;
+        expires_in?: number;
+      }>('https://id.kick.com/oauth/token', {
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: 'client_credentials',
+      }, {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
+
+      await this.saveToken(data.access_token, data.expires_in);
+
+      return data.access_token;
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to get kick client credentials token: ${getAxiosMessage(error)}`,
+      );
+    }
+  }
+
+  async getCachedToken() {
+    return this.cacheManager.get<string | null>(
+      'kick-client-credentials-token',
+    );
+  }
+
+  async saveToken(token: string, expiresIn?: number) {
+    const ttl = Math.max((expiresIn || 3600) - 60, 60);
+
+    return await this.cacheManager.set('kick-client-credentials-token', token, {
+      ttl,
+    } as any);
+  }
+
+  @Cron(CronExpression.EVERY_30_MINUTES)
+  async refreshToken() {
+    try {
+      await this.getAndSaveClientToken();
+    } catch (error) {
+      this.logger.error('Failed to refresh kick client credentials token');
+    }
+  }
+}

--- a/server/src/integrations/kick/kick.module.ts
+++ b/server/src/integrations/kick/kick.module.ts
@@ -1,0 +1,11 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { KickService } from './kick.service';
+import { KickTokenService } from './kick-token.service';
+
+@Module({
+  imports: [HttpModule.register({})],
+  providers: [KickService, KickTokenService],
+  exports: [KickService, KickTokenService],
+})
+export class KickModule {}

--- a/server/src/integrations/kick/kick.service.ts
+++ b/server/src/integrations/kick/kick.service.ts
@@ -1,0 +1,89 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { getAxiosMessage } from 'src/shared/utils/errors';
+import { KickTokenService } from './kick-token.service';
+
+export interface KickChannel {
+  broadcaster_user_id?: number;
+  slug?: string;
+}
+
+export interface KickLivestream {
+  broadcaster_user_id?: number;
+  channel_id?: number;
+  slug?: string;
+  started_at?: string;
+  stream_title?: string;
+  thumbnail?: string;
+  viewer_count?: number;
+}
+
+@Injectable()
+export class KickService {
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly kickTokenService: KickTokenService,
+  ) {}
+
+  async getChannelsBySlug(slugs: string[]) {
+    const uniqueSlugs = [...new Set(slugs.filter(Boolean))].slice(0, 50);
+    if (!uniqueSlugs.length) return [];
+
+    const accessToken = await this.kickTokenService.getClientToken();
+    if (!accessToken) return [];
+
+    try {
+      const { data } = await this.httpService.axiosRef.get<{
+        data?: KickChannel[];
+      }>('https://api.kick.com/public/v1/channels', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        params: {
+          slug: uniqueSlugs,
+        },
+        paramsSerializer: {
+          indexes: null,
+        },
+      });
+
+      return data.data || [];
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to get channels from Kick: ${getAxiosMessage(error)}`,
+      );
+    }
+  }
+
+  async getLivestreamsByBroadcasterIds(broadcasterIds: number[]) {
+    const uniqueIds = [
+      ...new Set(broadcasterIds.filter((id): id is number => Boolean(id))),
+    ].slice(0, 50);
+    if (!uniqueIds.length) return [];
+
+    const accessToken = await this.kickTokenService.getClientToken();
+    if (!accessToken) return [];
+
+    try {
+      const { data } = await this.httpService.axiosRef.get<{
+        data?: KickLivestream[];
+      }>('https://api.kick.com/public/v1/livestreams', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        params: {
+          broadcaster_user_id: uniqueIds,
+        },
+        paramsSerializer: {
+          indexes: null,
+        },
+      });
+
+      return data.data || [];
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to get live streams from Kick: ${getAxiosMessage(error)}`,
+      );
+    }
+  }
+}

--- a/server/src/live-streams/live-streams.module.ts
+++ b/server/src/live-streams/live-streams.module.ts
@@ -16,11 +16,14 @@ import { RumbleProvider } from './providers/rumble.provider';
 import { QueuesModule } from 'src/queues/queues.module';
 import { PeertubeModule } from 'src/integrations/peertube/peertube.module';
 import { PeertubeProvider } from './providers/peertube.provider';
+import { KickModule } from 'src/integrations/kick/kick.module';
+import { KickProvider } from './providers/kick.provider';
 
 @Module({
   imports: [
     YoutubeModule,
     TwitchModule,
+    KickModule,
     RumbleModule,
     PeertubeModule,
     LinksModule,
@@ -32,6 +35,7 @@ import { PeertubeProvider } from './providers/peertube.provider';
     LiveStreamsService,
     YoutubeProvider,
     TwitchProvider,
+    KickProvider,
     RumbleProvider,
     PeertubeProvider,
     LiveStreamProcessor,

--- a/server/src/live-streams/live-streams.service.ts
+++ b/server/src/live-streams/live-streams.service.ts
@@ -19,6 +19,7 @@ import { RumbleProvider } from './providers/rumble.provider';
 import { Link } from 'src/links/link.entity';
 import { Tip } from 'src/tips/tip.entity';
 import { PeertubeProvider } from './providers/peertube.provider';
+import { KickProvider } from './providers/kick.provider';
 
 @Injectable()
 export class LiveStreamsService implements OnModuleInit {
@@ -28,6 +29,7 @@ export class LiveStreamsService implements OnModuleInit {
     private linksService: LinksService,
     private youtubeProvider: YoutubeProvider,
     private twitchProvider: TwitchProvider,
+    private kickProvider: KickProvider,
     private rumbleProvider: RumbleProvider,
     private peertubeProvider: PeertubeProvider,
     private config: ConfigService,
@@ -55,10 +57,11 @@ export class LiveStreamsService implements OnModuleInit {
       .addOrderBy(
         `CASE 
           WHEN liveStream.platform = '${LiveStreamPlatformEnum.TWITCH}' THEN 1
-          WHEN liveStream.platform = '${LiveStreamPlatformEnum.PEERTUBE}' THEN 2
-          WHEN liveStream.platform = '${LiveStreamPlatformEnum.YOUTUBE}' THEN 3
-          WHEN liveStream.platform = '${LiveStreamPlatformEnum.RUMBLE}' THEN 4
-          ELSE 5
+          WHEN liveStream.platform = '${LiveStreamPlatformEnum.KICK}' THEN 2
+          WHEN liveStream.platform = '${LiveStreamPlatformEnum.PEERTUBE}' THEN 3
+          WHEN liveStream.platform = '${LiveStreamPlatformEnum.YOUTUBE}' THEN 4
+          WHEN liveStream.platform = '${LiveStreamPlatformEnum.RUMBLE}' THEN 5
+          ELSE 6
         END`,
         'ASC',
       )
@@ -94,12 +97,14 @@ export class LiveStreamsService implements OnModuleInit {
   async getAndUpdateLiveStreams() {
     const youtube = await this.getYoutubeLiveStreams();
     const twitch = await this.getTwitchLiveStreams();
+    const kick = await this.getKickLiveStreams();
     const rumble = await this.getRumbleLiveStreams();
     const peertube = await this.getPeertubeLiveStreams();
 
     await this.updateLiveStreams([
       ...youtube,
       ...twitch,
+      ...kick,
       ...rumble,
       ...peertube,
     ]);
@@ -142,6 +147,19 @@ export class LiveStreamsService implements OnModuleInit {
   async getTwitchLiveStreams() {
     const params = await this.getTwitchProviderParams();
     return this.twitchProvider.getLiveStreams(params);
+  }
+
+  async getKickLiveStreams() {
+    const links = await this.linksService.findByPlatform(LinkPlatformEnum.KICK);
+
+    const params = links.map((link) => ({
+      username: link.value,
+      pageId: link.page.id,
+    }));
+
+    const streams = await this.kickProvider.getLiveStreams(params);
+
+    return streams;
   }
 
   async getYoutubeLiveStreams() {

--- a/server/src/live-streams/providers/kick.provider.ts
+++ b/server/src/live-streams/providers/kick.provider.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  KickChannel,
+  KickLivestream,
+  KickService,
+} from 'src/integrations/kick/kick.service';
+import { LiveStreamPlatformEnum } from 'src/shared/constants';
+import { getErrorMessage } from 'src/shared/utils/errors';
+import { CreateLiveStreamDto } from '../dtos/create-live-stream.dto';
+import {
+  LiveStreamProvider,
+  LiveStreamProviderParams,
+} from './live-stream-provider.interface';
+
+type KickProviderParam = LiveStreamProviderParams & { username: string };
+
+@Injectable()
+export class KickProvider implements LiveStreamProvider {
+  private logger = new Logger(KickProvider.name);
+
+  constructor(private readonly kickService: KickService) {}
+
+  async getLiveStreams(
+    params: LiveStreamProviderParams[],
+  ): Promise<CreateLiveStreamDto[]> {
+    if (!params.length) return [];
+
+    const pageParams = params.filter(
+      (param): param is KickProviderParam => Boolean(param.username),
+    );
+
+    if (!pageParams.length) return [];
+
+    try {
+      const channels = await this.kickService.getChannelsBySlug(
+        pageParams.map((param) => param.username),
+      );
+      const streams = await this.kickService.getLivestreamsByBroadcasterIds(
+        channels.map((channel) => channel.broadcaster_user_id).filter(Boolean),
+      );
+
+      return pageParams
+        .map((param) => {
+          const channel = this.findChannel(channels, param.username);
+          const stream = streams.find(
+            (stream) =>
+              stream.broadcaster_user_id === channel?.broadcaster_user_id,
+          );
+
+          if (!channel || !stream) return;
+
+          return this.toLiveStreamDto(stream, channel, param.pageId);
+        })
+        .filter((stream): stream is CreateLiveStreamDto => Boolean(stream));
+    } catch (error) {
+      this.logger.error(
+        `Failed to get live streams from Kick: ${getErrorMessage(error)}`,
+      );
+    }
+
+    return [];
+  }
+
+  private findChannel(channels: KickChannel[], slug: string) {
+    return channels.find(
+      (channel) => channel.slug?.toLowerCase() === slug.toLowerCase(),
+    );
+  }
+
+  private toLiveStreamDto(
+    stream: KickLivestream,
+    channel: KickChannel,
+    pageId: number,
+  ): CreateLiveStreamDto {
+    const slug = stream.slug || channel.slug;
+
+    return {
+      title: stream.stream_title,
+      channelId: String(stream.channel_id || stream.broadcaster_user_id),
+      channelName: slug,
+      imageUrl: stream.thumbnail,
+      platform: LiveStreamPlatformEnum.KICK,
+      viewerCount: stream.viewer_count,
+      videoId: slug,
+      startedAt: stream.started_at,
+      pageId,
+    };
+  }
+}

--- a/server/src/shared/constants/enum.ts
+++ b/server/src/shared/constants/enum.ts
@@ -170,6 +170,7 @@ export enum PageRecipientVariant {
 export enum LiveStreamPlatformEnum {
   YOUTUBE = 'youtube',
   TWITCH = 'twitch',
+  KICK = 'kick',
   X = 'x',
   RUMBLE = 'rumble',
   PEERTUBE = 'peertube',


### PR DESCRIPTION
## Summary
  - Add Kick as a supported live stream platform.
  - Add Kick API integration using client credentials.
  - Add Kick live stream discovery and refresh support.
  - Render Kick streams with the Kick embedded player.

  ## Testing
  - Verified Kick stream rendering locally on a test page.
