### PR TITLE
Add GitLab and Matrix content links

### DIFF
--- a/client/composables/useConstants.ts
+++ b/client/composables/useConstants.ts
@@ -189,6 +189,22 @@ export const useConstants = () => {
       inputLabel: "GitHub link (enter full URL)",
       linkCreator: (v?: string) => `${v}`,
     },
+    [ContentLinkPlatformEnum.GITLAB]: {
+      name: "GitLab",
+      colorClassName: "text-[#FC6D26]",
+      iconClassName: "",
+      icon: "i-tabler-brand-gitlab",
+      inputLabel: "GitLab link (enter full URL)",
+      linkCreator: (v?: string) => `${v}`,
+    },
+    [ContentLinkPlatformEnum.MATRIX]: {
+      name: "Matrix",
+      colorClassName: "",
+      iconClassName: "",
+      icon: "i-simple-icons-matrix",
+      inputLabel: "Matrix ID (for example @user:matrix.org)",
+      linkCreator: (v?: string) => `https://matrix.to/#/${v}`,
+    },
     [ContentLinkPlatformEnum.MONERO_JOBS]: {
       name: "Monero Jobs",
       colorClassName: "text-[#FF6600]",

--- a/client/composables/useValidations.ts
+++ b/client/composables/useValidations.ts
@@ -132,6 +132,17 @@ export const useValidations = (generalV?: Ref<Validation>) => {
     notStartingWithAtBase
   );
 
+  const matrixIdBase = (v: any) => {
+    if (!v) return true;
+    if (typeof v !== "string") return false;
+    return /^@[^\s:]+:[^\s:]+$/.test(v.trim());
+  };
+
+  const matrixId = helpers.withMessage(
+    "Enter a Matrix ID like @user:matrix.org.",
+    matrixIdBase
+  );
+
   const getValidationAttrs = (path: string, v?: MaybeRef<Validation>) => {
     v = unref(v || generalV);
     const instance = getProperty(v, path);
@@ -172,6 +183,7 @@ export const useValidations = (generalV?: Ref<Validation>) => {
     moneroPrimaryAddress,
     rumbleApiUrl,
     notStartingWithAt,
+    matrixId,
     getValidationAttrs,
     validate,
   };

--- a/client/locales/en.ts
+++ b/client/locales/en.ts
@@ -322,7 +322,7 @@ export default {
   kunoFundraiser: "Kuno fundraiser",
   rumbleLiveStreamApi: "Rumble live stream API",
   rumbleLiveStreamApiHelp:
-    "Rumble live stream API from {guide}. XMRChat uses this URL for getting current live streams of your channel.",
+    "Rumble live stream API from {guide}. XMRChat uses this URL to feature your livestream on our homepage.",
   thisGuide: "this guide",
 
   // OBS

--- a/client/pages/streamer/content-links/index.vue
+++ b/client/pages/streamer/content-links/index.vue
@@ -18,7 +18,8 @@ interface State {
 }
 
 const { getMyLinks: getMyLinksReq, updateLinks } = useServices();
-const { url, notUrl, rumbleApiUrl, notStartingWithAt } = useValidations();
+const { url, notUrl, rumbleApiUrl, notStartingWithAt, matrixId } =
+  useValidations();
 const toast = useToast();
 const { getContentLink } = useConstants();
 const { t } = useI18n();
@@ -67,6 +68,8 @@ const state = reactive<State>({
       patreon: {},
       subscribestar: {},
       github: {},
+      gitlab: {},
+      matrix: {},
       "monero-jobs": {},
       facebook: {},
     },
@@ -115,6 +118,8 @@ const rules = computed(() => {
     PATREON,
     SUBSCRIBESTAR,
     GITHUB,
+    GITLAB,
+    MATRIX,
     MONERO_JOBS,
     ...rest
   } = ContentLinkPlatformEnum;
@@ -143,6 +148,8 @@ const rules = computed(() => {
       [PATREON]: { value: { url } },
       [SUBSCRIBESTAR]: { value: { url } },
       [GITHUB]: { value: { url } },
+      [GITLAB]: { value: { url } },
+      [MATRIX]: { value: { matrixId } },
       [MONERO_JOBS]: { value: { url } },
       ...notUrls,
     },

--- a/client/types/enums.ts
+++ b/client/types/enums.ts
@@ -44,6 +44,8 @@ export enum ContentLinkPlatformEnum {
   PATREON = "patreon",
   SUBSCRIBESTAR = "subscribestar",
   GITHUB = "github",
+  GITLAB = "gitlab",
+  MATRIX = "matrix",
   MONERO_JOBS = "monero-jobs",
   FACEBOOK = "facebook",
 }

--- a/client/utils/constants.ts
+++ b/client/utils/constants.ts
@@ -13,7 +13,6 @@ export const CONTENT_LINKS_LIST = [
   ContentLinkPlatformEnum.INSTAGRAM,
   ContentLinkPlatformEnum.WEBSITE,
   ContentLinkPlatformEnum.YOUTUBE,
-  ContentLinkPlatformEnum.RUMBLE,
   ContentLinkPlatformEnum.TWITCH,
   ContentLinkPlatformEnum.TIKTOK,
   ContentLinkPlatformEnum.ODYSEE,
@@ -27,8 +26,11 @@ export const CONTENT_LINKS_LIST = [
   ContentLinkPlatformEnum.PATREON,
   ContentLinkPlatformEnum.SUBSCRIBESTAR,
   ContentLinkPlatformEnum.GITHUB,
+  ContentLinkPlatformEnum.GITLAB,
+  ContentLinkPlatformEnum.MATRIX,
   ContentLinkPlatformEnum.MONERO_JOBS,
   ContentLinkPlatformEnum.FACEBOOK,
+  ContentLinkPlatformEnum.RUMBLE,
 ];
 
 export const SWAP_STATUSES = {

--- a/server/src/live-streams/live-streams.service.ts
+++ b/server/src/live-streams/live-streams.service.ts
@@ -48,12 +48,13 @@ export class LiveStreamsService implements OnModuleInit {
   }
 
   async findAll() {
-    return this.repo
+    const streams = await this.repo
       .createQueryBuilder('liveStream')
       .leftJoinAndSelect('liveStream.page', 'page')
       .leftJoinAndSelect('page.logo', 'logo')
       .distinctOn(['page.id'])
       .orderBy('page.id', 'ASC')
+      .addOrderBy('liveStream.startedAt', 'DESC', 'NULLS LAST')
       .addOrderBy(
         `CASE 
           WHEN liveStream.platform = '${LiveStreamPlatformEnum.TWITCH}' THEN 1
@@ -66,6 +67,10 @@ export class LiveStreamsService implements OnModuleInit {
         'ASC',
       )
       .getMany();
+
+    return streams.sort((a, b) => {
+      return (b.startedAt?.getTime() || 0) - (a.startedAt?.getTime() || 0);
+    });
   }
 
   async updateLiveStreams(dto: CreateLiveStreamDto[]) {

--- a/server/src/shared/constants/enum.ts
+++ b/server/src/shared/constants/enum.ts
@@ -81,6 +81,8 @@ export enum LinkPlatformEnum {
   PATREON = 'patreon',
   SUBSCRIBESTAR = 'subscribestar',
   GITHUB = 'github',
+  GITLAB = 'gitlab',
+  MATRIX = 'matrix',
   MONERO_JOBS = 'monero-jobs',
   FACEBOOK = 'facebook',
 }


### PR DESCRIPTION
  ## Summary

  - Add GitLab and Matrix as supported content link platforms
  - Validate GitLab as a full URL and Matrix as a Matrix ID
  - Move Rumble lower in the content links list so it sits closer to the live
  stream API field
  - Update the Rumble live stream API helper text
  - Sort featured live streams newest-first on the homepage

  ## Notes

  The Rumble API helper keeps the existing guide link text and updates the
  description to say the URL is used to feature livestreams on the homepage.

